### PR TITLE
Skip serializing if value is empty

### DIFF
--- a/google_rest_api_generator/src/lib.rs
+++ b/google_rest_api_generator/src/lib.rs
@@ -1272,7 +1272,7 @@ impl Type {
                                 field.attrs.extend(
                                     syn::Attribute::parse_outer
                                         .parse2(quote! {
-                                            #[serde(rename=#id,default)]
+                                            #[serde(rename=#id,default,skip_serializing_if="std::option::Option::is_none")]
                                         })
                                         .expect("failed to parse serde attr"),
                                 );


### PR DESCRIPTION
I'm hitting problems when using the generated storage APIs. It looks like the default behavior is to serialize all fields of the schema with null JSON values in the body, but I've found that Google storage APIs don't consider this valid (see eg [the api explorer](https://cloud.google.com/storage/docs/json_api/v1/buckets/insert?apix_params=%7B%22project%22%3A%22octomizer-dev%22%2C%22resource%22%3A%7B%22locationType%22%3Anull%2C%22name%22%3A%22ffd705c0-1e8b-4e8c-aacb-a8dbe1726a775%22%7D%7D) )

It seems like the default serde annotation on these fields should be `#[serde(default,skip_serializing_if = "Option::is_none")]` instead of just `default`. And indeed, that enables my tests on both storage and pubsub to pass.