### PR TITLE
[OAuth] Bump yup_oauth2 to its latest version.

### DIFF
--- a/google_api_auth/Cargo.toml
+++ b/google_api_auth/Cargo.toml
@@ -11,5 +11,6 @@ default = []
 with-yup-oauth2 = ["yup-oauth2", "tokio"]
 
 [dependencies]
-yup-oauth2 = { version = "^3.1", optional = true }
-tokio = { version = "0.1", optional = true }
+yup-oauth2 = { version = "^4.1", optional = true }
+tokio = { version = "0.2", optional = true }
+hyper = "^0.13"


### PR DESCRIPTION
Trying to navigate versioning hell with hyper, tls, etc. I believe this should just work, let me know if there is any more process to follow on sending PRs to this repo. I also regenerated all of the crates, and they appear to work. Any tips would be appreciated :) 