### PR TITLE
Rearrange the where clause for generated Client::new() constructors

### DIFF
--- a/google_rest_api_generator/src/lib.rs
+++ b/google_rest_api_generator/src/lib.rs
@@ -296,7 +296,7 @@ impl APIDesc {
             impl Client {
                 pub fn new<A>(auth: A) -> Self
                 where
-                    A: Into<Box<dyn ::google_api_auth::GetAccessToken>>,
+                    A: ::google_api_auth::GetAccessToken + 'static,
                 {
                     Client::with_reqwest_client(
                         auth,
@@ -308,11 +308,11 @@ impl APIDesc {
                 // configuration knobs we should switch to a builder pattern.
                 pub fn with_reqwest_client<A>(auth: A, reqwest: ::reqwest::blocking::Client) -> Self
                 where
-                    A: Into<Box<dyn ::google_api_auth::GetAccessToken>>,
+                    A: ::google_api_auth::GetAccessToken + 'static,
                 {
                     Client {
                         reqwest,
-                        auth: auth.into(),
+                        auth: Box::new(auth),
                     }
                 }
 


### PR DESCRIPTION
This PR rearranges the where clause on `Client::new()` to make it work with type inference and `impl Trait` better.

---

Clients [currently explicitly require](https://github.com/google-apis-rs/generated/blob/1f027cd825cd0b7c415bf475cd14d371b517e90d/gen/translate/v3/lib/src/lib.rs#L1235-L1237) that an `auth` can be turned into a `Box<dyn GetAccessToken>`, but this doesn't play well with `impl Trait` and the `impl GetAccessToken` returned by `google_api_auth::yup_oauth2::from_authenticator()`.

For example, I am trying to use the following code:

```rust
let app_secret: ApplicationSecret = args.load_app_secret()?;

let authenticator = DeviceFlowAuthenticator::builder(app_secret)
    .persist_tokens_to_disk(
        PROJECT_DIRS.cache_dir().join("token-cache.json"),
    )
    .build()
    .await
    .context("Unable to create the OAuth2 authenticator")?;


let scopes = vec!["https://www.googleapis.com/auth/cloud-translation"];
let get_access_token =
    google_api_auth::yup_oauth2::from_authenticator(authenticator, scopes);
let client = Client::new(get_access_token);
```

[(original code)](https://gitlab.com/wintech-engineering/fluent-machine-translations/-/blob/93d308653ed1c76894cadababb63568ada6ad167/cli/src/main.rs#L14-27)

And `rustc`  fails with the unhelpful error message *"the trait bound `impl google_api_auth::GetAccessToken: std::convert::From<impl google_api_auth::GetAccessToken>` is not satisfied"*... Which doesn't make sense considering `T: From<T>`.

```text
error[E0277]: the trait bound `impl google_api_auth::GetAccessToken: std::convert::From<impl google_api_auth::GetAccessToken>` is not satisfied
    --> cli\src\main.rs:27:30
     |
27   |     let client = Client::new(get_access_token);
     |                              ^^^^^^^^^^^^^^^^
     |                              |
     |                              expected an implementor of trait `std::convert::From<impl google_api_auth::GetAccessToken>`
     |                              help: consider borrowing here: `&get_access_token`
     |
    ::: C:\Users\mbryan\.cargo\git\checkouts\generated-f06055b20a4066fd\1f027cd\gen\translate\v3\lib\src\lib.rs:1237:12
     |
1237 |         A: Into<Box<dyn ::google_api_auth::GetAccessToken>>,
     |            ------------------------------------------------ required by this bound in `google_translate3::Client::new`
     |
     = note: required because of the requirements on the impl of `std::convert::From<impl google_api_auth::GetAccessToken>` for `std::boxed::Box<(dyn google_api_auth::GetAccessToken + 'static)>`
     = note: required because of the requirements on the impl of `std::convert::Into<std::boxed::Box<(dyn google_api_auth::GetAccessToken + 'static)>>` for `impl google_api_auth::GetAccessToken`

error: aborting due to previous error
```

This is linked to #24 in that the user experience for authentication isn't great.